### PR TITLE
quit wm

### DIFF
--- a/src/windowmanager.rs
+++ b/src/windowmanager.rs
@@ -175,6 +175,7 @@ impl WindowManager {
                     },
                     WmCommands::Quit => {
                         println!("Quit");
+                        std::process::exit(0);
                     },
                     WmCommands::Kill => {
                         println!("Kill");


### PR DESCRIPTION
exit wm. There is no disconnect method for the RustConnection so I guess killing it is just fine.