### PR TITLE
reintroduce next layout

### DIFF
--- a/src/windowmanager/mod.rs
+++ b/src/windowmanager/mod.rs
@@ -207,9 +207,7 @@ impl WindowManager {
                 }
                 active_workspace.set_layout(layout.unwrap());
             },
-            None => {
-                active_workspace.next_layout();
-            },
+            None => active_workspace.next_layout(),
         }
     }
 


### PR DESCRIPTION
This functionality was already written but somehow the None case handling had been changed. 
Original introduction with: 271ff27654df1ecd2b5a537032c8b9f240aa3f5b