### PR TITLE
home config not found

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -57,11 +57,13 @@ pub struct Config {
 
 impl Config {
     pub fn new() -> Config {
+        let home_config = &format!("{}/.config/oxide/config.yml", std::env::var("HOME").unwrap());
+
         #[cfg(not(debug_assertions))]
-        let paths = vec!["~/.config/oxide/config.yml", "/etc/oxide/config.yml"];
+        let paths = vec![home_config, "/etc/oxide/config.yml"];
         
         #[cfg(debug_assertions)]
-        let paths = vec!["./config.yml", "~/.config/oxide/config.yml", "/etc/oxide/config.yml"];
+        let paths = vec!["./config.yml", home_config, "/etc/oxide/config.yml"];
         
         let mut chosen_config: Option<&str> = None;
         let mut file_option: Option<File> = None;


### PR DESCRIPTION
The tilde is replaced by vie a hard path and this works