### PR TITLE
class diagrams on rtd

### DIFF
--- a/docs/source/033_class_diagrams_generated/windowmanager/index.rst
+++ b/docs/source/033_class_diagrams_generated/windowmanager/index.rst
@@ -4,8 +4,6 @@
 windowmanager
 ========================================================
 
-
-
 All shown class diagrams are **automatically generated**.
 
 .. toctree::
@@ -61,7 +59,7 @@ auxiliary
 
 .. figure:: ../../../../planning/diagrams/classdg_generated/windowmanager/auxiliary.png
     :align: center
-    :width: 750px
+    :width: 450px
 
     auxiliary.png
 


### PR DESCRIPTION
@janschaible Another day, another pr ;)
Watched your changes regarding the class diagrams - looks really great!
What do you think of creating one more separate page for here: https://oxide.readthedocs.io/en/latest/033_class_diagrams_generated/windowmanager/index.html
If you click on the topic windowmanager, you will not expect diagrams to be shown in the lower half of the site. I am afraid someone could overlook the placed diagrams. I will suggest to make a separate page for those general diagrams (keybindings, ipc, main and auxiliary". Maybe we coould switch the sequence so that main is the first one?

I can gladly add these changes, but i don't know if it works with your automatic generation. :)